### PR TITLE
Changes to be able to specify source field from event to be validated

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,0 +1,138 @@
+PATH
+  remote: .
+  specs:
+    logstash-filter-json_schema (0.2.0)
+      json-schema (~> 2.6)
+      logstash-core-plugin-api (~> 2.0)
+
+GEM
+  remote: https://rubygems.org/
+  specs:
+    addressable (2.5.2)
+      public_suffix (>= 2.0.2, < 4.0)
+    chronic_duration (0.10.6)
+      numerizer (~> 0.1.1)
+    clamp (0.6.5)
+    coderay (1.1.2)
+    concurrent-ruby (1.1.3)
+    diff-lcs (1.3)
+    elasticsearch (5.0.5)
+      elasticsearch-api (= 5.0.5)
+      elasticsearch-transport (= 5.0.5)
+    elasticsearch-api (5.0.5)
+      multi_json
+    elasticsearch-transport (5.0.5)
+      faraday
+      multi_json
+    faraday (0.15.3)
+      multipart-post (>= 1.2, < 3)
+    ffi (1.9.25-java)
+    filesize (0.0.4)
+    fivemat (1.3.7)
+    gem_publisher (1.5.0)
+    gems (0.8.3)
+    i18n (0.6.9)
+    insist (1.0.0)
+    jar-dependencies (0.4.0)
+    jrjackson (0.4.6-java)
+    jruby-openssl (0.9.19-java)
+    json-schema (2.8.1)
+      addressable (>= 2.4)
+    kramdown (1.14.0)
+    logstash-core (5.6.4-java)
+      chronic_duration (= 0.10.6)
+      clamp (~> 0.6.5)
+      concurrent-ruby (~> 1.0, >= 1.0.5)
+      elasticsearch (~> 5.0, >= 5.0.4)
+      filesize (= 0.0.4)
+      gems (~> 0.8.3)
+      i18n (= 0.6.9)
+      jar-dependencies
+      jrjackson (~> 0.4.3)
+      jruby-openssl (= 0.9.19)
+      manticore (>= 0.5.4, < 1.0.0)
+      minitar (~> 0.5.4)
+      pry (~> 0.10.1)
+      puma (~> 2.16)
+      rack (= 1.6.6)
+      ruby-maven (~> 3.3.9)
+      rubyzip (~> 1.1.7)
+      sinatra (~> 1.4, >= 1.4.6)
+      stud (~> 0.0.19)
+      thread_safe (~> 0.3.5)
+      treetop (< 1.5.0)
+    logstash-core-plugin-api (2.1.28-java)
+      logstash-core (= 5.6.4)
+    logstash-devutils (1.3.6-java)
+      fivemat
+      gem_publisher
+      insist (= 1.0.0)
+      kramdown (= 1.14.0)
+      logstash-core-plugin-api (>= 2.0, <= 2.99)
+      minitar
+      rake
+      rspec (~> 3.0)
+      rspec-wait
+      stud (>= 0.0.20)
+    manticore (0.6.4-java)
+      openssl_pkcs8_pure
+    method_source (0.8.2)
+    minitar (0.5.4)
+    multi_json (1.13.1)
+    multipart-post (2.0.0)
+    numerizer (0.1.1)
+    openssl_pkcs8_pure (0.0.0.2)
+    polyglot (0.3.5)
+    pry (0.10.4-java)
+      coderay (~> 1.1.0)
+      method_source (~> 0.8.1)
+      slop (~> 3.4)
+      spoon (~> 0.0)
+    public_suffix (3.0.3)
+    puma (2.16.0-java)
+    rack (1.6.6)
+    rack-protection (1.5.5)
+      rack
+    rake (12.3.1)
+    rspec (3.8.0)
+      rspec-core (~> 3.8.0)
+      rspec-expectations (~> 3.8.0)
+      rspec-mocks (~> 3.8.0)
+    rspec-core (3.8.0)
+      rspec-support (~> 3.8.0)
+    rspec-expectations (3.8.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-mocks (3.8.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.8.0)
+    rspec-support (3.8.0)
+    rspec-wait (0.0.9)
+      rspec (>= 3, < 4)
+    ruby-maven (3.3.12)
+      ruby-maven-libs (~> 3.3.9)
+    ruby-maven-libs (3.3.9)
+    rubyzip (1.1.7)
+    sinatra (1.4.8)
+      rack (~> 1.5)
+      rack-protection (~> 1.4)
+      tilt (>= 1.3, < 3)
+    slop (3.6.0)
+    spoon (0.0.6)
+      ffi
+    stud (0.0.23)
+    thread_safe (0.3.6-java)
+    tilt (2.0.8)
+    treetop (1.4.15)
+      polyglot
+      polyglot (>= 0.3.1)
+
+PLATFORMS
+  java
+
+DEPENDENCIES
+  logstash-devutils
+  logstash-filter-json_schema!
+
+BUNDLED WITH
+   1.17.1

--- a/lib/logstash/filters/json_schema.rb
+++ b/lib/logstash/filters/json_schema.rb
@@ -15,6 +15,8 @@ class LogStash::Filters::JsonSchema < LogStash::Filters::Base
   # The schema to validate messages against.
   config :schema, :validate => :string, :default => "{}"
   
+  # The source field from the event to validate
+  config :source, :validate => :string, :default => "message"
 
   public
   def register
@@ -23,7 +25,7 @@ class LogStash::Filters::JsonSchema < LogStash::Filters::Base
 
   public
   def filter(event)
-    body = event.get("message")
+    body = event.get(@source)
     begin
       if !JSON::Validator.validate(@schema, body)
         tag_as_schema_failure(event)

--- a/logstash-filter-json_schema.gemspec
+++ b/logstash-filter-json_schema.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |s|
   s.name          = 'logstash-filter-json_schema'
-  s.version       = '0.2.0'
+  s.version       = '0.3.0'
   s.licenses      = ['Apache-2.0']
   s.summary       = 'Validates json input against a provided schema (https://json-schema.org)'
   s.homepage      = 'https://github.com/pluralsight/logstash-filter-json_schema'

--- a/spec/filters/json_schema_spec.rb
+++ b/spec/filters/json_schema_spec.rb
@@ -3,7 +3,7 @@ require_relative '../spec_helper'
 require "logstash/filters/json_schema"
 
 describe LogStash::Filters::JsonSchema do
-  describe "Validating schema" do
+  describe "Validating schema against default source field" do
     let(:config) do <<-CONFIG
       filter {
         json_schema {
@@ -18,6 +18,26 @@ describe LogStash::Filters::JsonSchema do
       expect(subject.get('tags')).to include('jsonschemafailure')
     end
     sample("message" => '{"userId": "123" }') do
+      expect(subject).not_to include("tags")
+    end
+  end
+
+  describe "Validating schema against specified source field" do
+    let(:config) do <<-CONFIG
+      filter {
+        json_schema {
+          schema => '{"type": "object", "properties": {"userId": {"type": "string" } }, "required":["userId"] }'
+          source => source_field
+        }
+      }
+    CONFIG
+    end
+
+    sample("source_field" => "{}") do
+      expect(subject).to include("tags")
+      expect(subject.get('tags')).to include('jsonschemafailure')
+    end
+    sample("source_field" => '{"userId": "123" }') do
       expect(subject).not_to include("tags")
     end
   end


### PR DESCRIPTION
Minor changes to allow the source field for validation to be provided as part of the plugin config. Existing default of master is preserved to allow for backwards compatibility with any existing configurations. Commit also includes two new test cases testing against the specified field rather than the defaults.